### PR TITLE
FIXED issue with dayViewHeight adjustments for months with 4 weeks

### DIFF
--- a/NWCalendar/NWCalendarMonthContentView.swift
+++ b/NWCalendar/NWCalendarMonthContentView.swift
@@ -220,7 +220,11 @@ extension NWCalendarMonthContentView {
       lastMonthMaxY = CGRectGetMaxY(lastMonthView.frame)
       
       if lastMonthView.numberOfWeeks == 6 || monthStartsOnFirstDayOfWeek(month) {
-        overlapOffset = dayViewHeight
+        if lastMonthView.numberOfWeeks == 4 {
+            overlapOffset = self.dayViewHeight * 2
+        } else {
+            overlapOffset = self.dayViewHeight
+        }
       } else {
         overlapOffset = dayViewHeight * 2
       }


### PR DESCRIPTION
I found you are adjusting following month views with offset by DayViewHeight in a following code.

```
  func createMonthViewForMonth(month: NSDateComponents) {
    var overlapOffset:CGFloat = 0
    var lastMonthMaxY:CGFloat = 0
    if monthViews.count > 0 {
      let lastMonthView = monthViews[monthViews.count-1]
      lastMonthMaxY = CGRectGetMaxY(lastMonthView.frame)

      if lastMonthView.numberOfWeeks == 6 || monthStartsOnFirstDayOfWeek(month) {
        overlapOffset = dayViewHeight
      } else {
        overlapOffset = dayViewHeight * 2
      }
    }
}
```

But this goes wrong in some places like Feb 2026. Because it is having only 4 rows of dates with just 28 days.

![simulator screen shot mar 1 2016 10 15 32 pm](https://cloud.githubusercontent.com/assets/3694584/13434941/dd254336-dffd-11e5-83e3-3b428564c685.png)
